### PR TITLE
Removed authorization check temporarily so other people can see arrangement

### DIFF
--- a/api/internal/core.js
+++ b/api/internal/core.js
@@ -126,18 +126,19 @@ exports.validatePostRequest = function (model, request) {
           return;
         }
 
+        // TODO: Check for authorization if private, if public skip verification
         // Authorization checks after validation
-        if (model.collectionName === 'arrangement') {
-          if (data.owner !== request.googleId) {
-            this.sendFailure(401, 'Unauthorized', 'Wrong credentials', resolve);
-            return;
-          }
-        } else {
-          if (data.user_data.googleId !== request.googleId) {
-            this.sendFailure(401, 'Unauthorized', 'Wrong credentials', resolve);
-            return;
-          }
-        }
+        // if (model.collectionName === 'arrangement') {
+        //   if (data.owner !== request.googleId) {
+        //     this.sendFailure(401, 'Unauthorized', 'Wrong credentials', resolve);
+        //     return;
+        //   }
+        // } else {
+        //   if (data.user_data.googleId !== request.googleId) {
+        //     this.sendFailure(401, 'Unauthorized', 'Wrong credentials', resolve);
+        //     return;
+        //   }
+        // }
 
         resolve({});
       })();


### PR DESCRIPTION
Currently, when a user loads an arrangement they also post to the arrangement. And if they are not authorized to do so, it will lock them out... This is confusing the signal, that if they no longer have a valid auth, they get logged out. So they are being logged out, when they try to post to an arrangement they aren't the owner of. 

I have to fix that bug on the FE. But for now, i'm temporarily disabling this check. I will put it back, once I figure out how to handle the session.